### PR TITLE
Fix for HMR when working in Electron

### DIFF
--- a/src/ngx-monaco-editor/src/lib/services/monaco-editor-loader.service.ts
+++ b/src/ngx-monaco-editor/src/lib/services/monaco-editor-loader.service.ts
@@ -14,6 +14,13 @@ export class MonacoEditorLoaderService {
 
     constructor(ngZone: NgZone) {
         const onGotAmdLoader = () => {
+            if ((<any>window).monacoEditorAlreadyInitialized) {
+                ngZone.run(() => this.isMonacoLoaded.next(true));
+                return
+            }
+
+            (<any>window).monacoEditorAlreadyInitialized = true;
+            
             // Load monaco
             (<any>window).amdRequire =  (<any>window).require;
             if (this.nodeRequire) {


### PR DESCRIPTION
Hello! Thank you for this library, it helped me a lot.

I faced some troubles using this package in Electron with enabled HMR option.
Every time i change my code, HMR instead of performing hotswap for changes just reloads whole page with this messages in console:
> [HMR] Cannot apply update. Need to do a full reload!
> [HMR] TypeError: window.amdRequire.config is not a function

I made a little investigation of  the problem and found that this happens when I'm using _MonacoEditorLoaderService_ in my main Angular module (to add json-schema) .

I analyzed _MonacoEditorLoaderService_ class and I suppose that it is unnecessary to modify _(<any>window).amdRequire_ and _(<any>window).require_ when this service is being created for a second time because global state in "window" global variable is already set.
So I made this simple fix.