### PR TITLE
Add default value to callbacks of MonacoEditorComponent

### DIFF
--- a/src/ngx-monaco-editor/src/lib/components/monaco-editor/monaco-editor.component.ts
+++ b/src/ngx-monaco-editor/src/lib/components/monaco-editor/monaco-editor.component.ts
@@ -84,7 +84,11 @@ export class MonacoEditorComponent implements OnInit, OnChanges, OnDestroy, Cont
       });
     }
 
-    constructor(private monacoLoader: MonacoEditorLoaderService) { }
+    constructor(private monacoLoader: MonacoEditorLoaderService) {
+      this.onTouched = () => { };
+      this.onErrorStatusChange = () => { };
+      this.propagateChange = (_: any) => { };
+    }
 
     ngOnInit() {
         this.monacoLoader.isMonacoLoaded$.pipe(


### PR DESCRIPTION
When not binding `[(ngModel)]` to `MonacoEditorComponent`, callbacks like `onTouched`, `onErrorStatusChange`, etc. are `undefined` and cause a lot of error messages.

I've opened issue #47 earlier this year, and I think this fix is a better solution.